### PR TITLE
fix: configurar email Brevo API y corregir warnings de Dialog

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -38,6 +38,9 @@ class Settings(BaseSettings):
     BREVO_API_KEY: Optional[str] = None
     EMAIL_FROM: str = "noreply@armentum.com"
     EMAIL_FROM_NAME: Optional[str] = None
+    CONTACT_EMAIL: str = "contacto@armentum.com"
+
+
     
     # App URL (for email links)
     APP_URL: str = "http://localhost:5173"

--- a/backend/app/services/email_service.py
+++ b/backend/app/services/email_service.py
@@ -1,11 +1,10 @@
 """
 Email Service
-Supports SendGrid and Resend providers with development fallback
+Supports SendGrid, Resend and Brevo providers with development fallback
 """
 
 import logging
 from abc import ABC, abstractmethod
-from email.message import EmailMessage
 
 from app.config import settings
 
@@ -119,45 +118,6 @@ class DevelopmentProvider(EmailProvider):
         return True
 
 
-class SMTPProvider(EmailProvider):
-    def __init__(self, host: str, port: int, username: str, password: str, use_tls: bool, use_ssl: bool):
-        self.host = host
-        self.port = port
-        self.username = username
-        self.password = password
-        self.use_tls = use_tls
-        self.use_ssl = use_ssl
-
-    async def send_email(self, to: str, subject: str, html_content: str) -> bool:
-        try:
-            import aiosmtplib
-
-            message = EmailMessage()
-            from_name = settings.EMAIL_FROM_NAME
-            from_address = settings.EMAIL_FROM
-            if from_name:
-                message["From"] = f"{from_name} <{from_address}>"
-            else:
-                message["From"] = from_address
-            message["To"] = to
-            message["Subject"] = subject
-            message.set_content("Esta es una notificación automática del Estudio Coral Armentum.")
-            message.add_alternative(html_content, subtype="html")
-
-            await aiosmtplib.send(
-                message,
-                hostname=self.host,
-                port=self.port,
-                username=self.username,
-                password=self.password,
-                start_tls=self.use_tls and not self.use_ssl,
-                use_tls=self.use_ssl,
-            )
-            return True
-        except Exception as e:
-            logger.error(f"SMTP error: {e}")
-            return False
-
 
 class EmailService:
     def __init__(self):
@@ -178,6 +138,7 @@ class EmailService:
 
         if provider_name == "brevo" and settings.BREVO_API_KEY:
             return BrevoProvider(settings.BREVO_API_KEY)
+
         logger.warning("No email provider configured, using development mode")
         return DevelopmentProvider()
 

--- a/src/app/components/ui/dialog.tsx
+++ b/src/app/components/ui/dialog.tsx
@@ -6,71 +6,63 @@ import { XIcon } from "lucide-react";
 
 import { cn } from "./utils";
 
-function Dialog({
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+function Dialog({ ...props }: React.ComponentProps<typeof DialogPrimitive.Root>) {
   return <DialogPrimitive.Root data-slot="dialog" {...props} />;
 }
 
-function DialogTrigger({
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+function DialogTrigger({ ...props }: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
   return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />;
 }
 
-function DialogPortal({
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+function DialogPortal({ ...props }: React.ComponentProps<typeof DialogPrimitive.Portal>) {
   return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />;
 }
 
-function DialogClose({
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+function DialogClose({ ...props }: React.ComponentProps<typeof DialogPrimitive.Close>) {
   return <DialogPrimitive.Close data-slot="dialog-close" {...props} />;
 }
 
-function DialogOverlay({
-  className,
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
-  return (
-    <DialogPrimitive.Overlay
-      data-slot="dialog-overlay"
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    data-slot="dialog-overlay"
+    className={cn(
+      "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+      className
+    )}
+    {...props}
+  />
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal data-slot="dialog-portal">
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      data-slot="dialog-content"
+      aria-describedby={undefined}
       className={cn(
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
-        className,
+        "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+        className
       )}
       {...props}
-    />
-  );
-}
-
-function DialogContent({
-  className,
-  children,
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Content>) {
-  return (
-    <DialogPortal data-slot="dialog-portal">
-      <DialogOverlay />
-      <DialogPrimitive.Content
-        data-slot="dialog-content"
-        className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
-          className,
-        )}
-        {...props}
-      >
-        {children}
-        <DialogPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4">
-          <XIcon />
-          <span className="sr-only">Close</span>
-        </DialogPrimitive.Close>
-      </DialogPrimitive.Content>
-    </DialogPortal>
-  );
-}
+    >
+      {children}
+      <DialogPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4">
+        <XIcon />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+));
+DialogContent.displayName = DialogPrimitive.Content.displayName;
 
 function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
   return (
@@ -86,19 +78,13 @@ function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="dialog-footer"
-      className={cn(
-        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
-        className,
-      )}
+      className={cn("flex flex-col-reverse gap-2 sm:flex-row sm:justify-end", className)}
       {...props}
     />
   );
 }
 
-function DialogTitle({
-  className,
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+function DialogTitle({ className, ...props }: React.ComponentProps<typeof DialogPrimitive.Title>) {
   return (
     <DialogPrimitive.Title
       data-slot="dialog-title"


### PR DESCRIPTION
## Summary

- **Email**: Agrega `CONTACT_EMAIL` a `Settings`, elimina `SMTPProvider` y las variables `SMTP_*` ya que el proyecto migró a Brevo API (`EMAIL_PROVIDER=brevo`)
- **Dialog**: Convierte `DialogOverlay` y `DialogContent` a `React.forwardRef` para resolver el warning de refs en Radix UI
- **Accesibilidad**: Agrega `aria-describedby={undefined}` en `DialogContent` para suprimir el warning de Radix cuando no se usa `DialogDescription`

## Variables de entorno requeridas en producción

```env
EMAIL_PROVIDER=brevo
BREVO_API_KEY=xkeysib-...
EMAIL_FROM=tu@email.com
EMAIL_FROM_NAME=Estudio Coral Armentum
CONTACT_EMAIL=destinatario@email.com
```